### PR TITLE
Install plugins in a standalone folder

### DIFF
--- a/plugins/actuation_delay/CMakeLists.txt
+++ b/plugins/actuation_delay/CMakeLists.txt
@@ -23,6 +23,6 @@ target_include_directories(ActuationDelay PRIVATE
 
 install(
     TARGETS ActuationDelay
-    LIBRARY DESTINATION lib
-    ARCHIVE DESTINATION lib
-    RUNTIME DESTINATION bin)
+    LIBRARY DESTINATION lib/gsp
+    ARCHIVE DESTINATION lib/gsp
+    RUNTIME DESTINATION bin/gsp)

--- a/plugins/low_pass_target/CMakeLists.txt
+++ b/plugins/low_pass_target/CMakeLists.txt
@@ -61,6 +61,6 @@ target_include_directories(LowPassTarget PRIVATE
 
 install(
     TARGETS LowPassTarget
-    LIBRARY DESTINATION lib
-    ARCHIVE DESTINATION lib
-    RUNTIME DESTINATION bin)
+    LIBRARY DESTINATION lib/gsp
+    ARCHIVE DESTINATION lib/gsp
+    RUNTIME DESTINATION bin/gsp)

--- a/python/gazebo_scenario_plugins/__init__.py
+++ b/python/gazebo_scenario_plugins/__init__.py
@@ -8,7 +8,7 @@ def setup_environment() -> None:
     folder containing the plugins of this repository.
     """
 
-    plugin_dir = Path(os.path.dirname(__file__)) / "lib"
+    plugin_dir = Path(os.path.dirname(__file__)) / "lib" / "gsp"
 
     if "IGN_GAZEBO_SYSTEM_PLUGIN_PATH" in os.environ:
         os.environ["IGN_GAZEBO_SYSTEM_PLUGIN_PATH"] += f":{plugin_dir}"


### PR DESCRIPTION
It allows separating the plugins from regular system libs when the plain CMake project is installed